### PR TITLE
fix: update TypeScript to version 5.9.3 and adjust deprecation settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
 				"prettier": "^2.5.1",
 				"pretty-quick": "^3.1.3",
 				"ts-node": "^10.4.0",
-				"typescript": "^4.5.2",
+				"typescript": "^5.9.3",
 				"uuid": "^8.3.2"
 			}
 		},
@@ -6225,16 +6225,17 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-			"integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/uglify-js": {
@@ -11138,9 +11139,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-			"integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"prettier": "^2.5.1",
 		"pretty-quick": "^3.1.3",
 		"ts-node": "^10.4.0",
-		"typescript": "^4.5.2",
+		"typescript": "^5.9.3",
 		"uuid": "^8.3.2"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"module": "commonjs",
 		"rootDir": "./src",
 		"moduleResolution": "node",
-		"ignoreDeprecations": "6.0",
+		"ignoreDeprecations": "5.0",
 		"outDir": "./build",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
This pull request updates the TypeScript dependency to the latest major version, ensuring compatibility with newer language features and improved type checking.

* Updated the `typescript` dependency in `package.json` from version `^4.5.2` to `^5.9.3`.