### PR TITLE
Staging to Main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
 				"prettier": "^2.5.1",
 				"pretty-quick": "^3.1.3",
 				"ts-node": "^10.4.0",
-				"typescript": "^4.5.2",
+				"typescript": "^5.9.3",
 				"uuid": "^8.3.2"
 			}
 		},
@@ -6225,16 +6225,17 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-			"integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
 			},
 			"engines": {
-				"node": ">=4.2.0"
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/uglify-js": {
@@ -11138,9 +11139,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-			"integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"prettier": "^2.5.1",
 		"pretty-quick": "^3.1.3",
 		"ts-node": "^10.4.0",
-		"typescript": "^4.5.2",
+		"typescript": "^5.9.3",
 		"uuid": "^8.3.2"
 	}
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,8 +48,8 @@ app.use(express.urlencoded({ extended: true }));
 // Channel is fetched lazily per-request via messageQueue.getChannel()
 // so it always returns the current live channel (handles reconnects).
 app.use((req: Request, res: Response, next: NextFunction) => {
-	(req as any).handleResponse = responseHandler;
-	(req as any).queue = messageQueue;
+	req.handleResponse = responseHandler;
+	req.queue = messageQueue;
 	next();
 });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -48,8 +48,8 @@ app.use(express.urlencoded({ extended: true }));
 // Channel is fetched lazily per-request via messageQueue.getChannel()
 // so it always returns the current live channel (handles reconnects).
 app.use((req: Request, res: Response, next: NextFunction) => {
-	req.handleResponse = responseHandler;
-	req.queue = messageQueue;
+	(req as any).handleResponse = responseHandler;
+	(req as any).queue = messageQueue;
 	next();
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
 		"module": "commonjs",
 		"rootDir": "./src",
 		"moduleResolution": "node",
-		"ignoreDeprecations": "6.0",
 		"outDir": "./build",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
@@ -19,9 +18,5 @@
 		"noImplicitReturns": false,
 		"noFallthroughCasesInSwitch": false
 	},
-	"include": ["src/**/*", "typings/**/*"],
-	"exclude": ["node_modules", "**/*.spec.ts"],
-	"ts-node": {
-		"files": true
-	}
+	"exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"module": "commonjs",
 		"rootDir": "./src",
 		"moduleResolution": "node",
-		"ignoreDeprecations": "6.0",
+		"ignoreDeprecations": "5.0",
 		"outDir": "./build",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"module": "commonjs",
 		"rootDir": "./src",
 		"moduleResolution": "node",
+		"ignoreDeprecations": "6.0",
 		"outDir": "./build",
 		"esModuleInterop": true,
 		"forceConsistentCasingInFileNames": true,
@@ -18,5 +19,9 @@
 		"noImplicitReturns": false,
 		"noFallthroughCasesInSwitch": false
 	},
-	"exclude": ["node_modules", "**/*.spec.ts"]
+	"include": ["src/**/*", "typings/**/*"],
+	"exclude": ["node_modules", "**/*.spec.ts"],
+	"ts-node": {
+		"files": true
+	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,9 @@
 		"noImplicitReturns": false,
 		"noFallthroughCasesInSwitch": false
 	},
-	"exclude": ["node_modules", "**/*.spec.ts"]
+	"include": ["src/**/*", "typings/**/*"],
+	"exclude": ["node_modules", "**/*.spec.ts"],
+	"ts-node": {
+		"files": true
+	}
 }


### PR DESCRIPTION
This pull request includes an upgrade to the TypeScript version and a minor change to how custom properties are assigned to the `req` object in Express middleware. These updates help keep dependencies current and improve compatibility with newer TypeScript features.

Dependency upgrades:

* Upgraded the `typescript` dependency from version `^4.5.2` to `^5.9.3` in `package.json` to ensure compatibility with newer TypeScript features and bug fixes.

Express middleware adjustments:

* Updated the middleware in `src/app.ts` to assign custom properties (`handleResponse` and `queue`) to the `req` object using type casting to `any`, improving compatibility with TypeScript's stricter type checking.