### PR TITLE
Add issue templates for bug reports, feature requests, and discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,69 @@
+name: "Bug Report"
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please provide all required details below.
+
+  # Description 
+  - type: textarea
+    id: steps
+    attributes:
+      label: Description / Steps to reproduce
+      description: Explain the issue and how to reproduce it
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See error
+    validations:
+      required: true
+
+  # Expected vs Actual behavior
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  # Screenshots 
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Drag & drop images or paste screenshots here 
+    validations:
+      required: false
+
+  # Environment info
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment / Version info
+      description: OS, browser, app version, device, etc.
+      placeholder: |
+        OS: Windows 11
+        Browser: Chrome 121
+        Version: 1.0.0
+    validations:
+      required: true
+
+  # Code of Conduct
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,59 @@
+name: "Feature Request"
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature. Please provide the details below.
+
+  # Problem / Motivation
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / Motivation
+      description: What problem or limitation would this feature address?
+      placeholder: Describe the challenge or pain point you are experiencing.
+    validations:
+      required: true
+
+  # Proposed Solution
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature or improvement you would like to see.
+      placeholder: Explain how you think this feature should work.
+    validations:
+      required: true
+
+  # Alternatives Considered
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you have considered.
+      placeholder: Have you considered other approaches?
+    validations:
+      required: false
+
+  # Additional Context
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context, examples, mockups, or screenshots related to the request.
+      placeholder: Include any supporting information that may help reviewers understand the request.
+    validations:
+      required: false
+
+  # Code of Conduct
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/3-general.yml
+++ b/.github/ISSUE_TEMPLATE/3-general.yml
@@ -1,0 +1,60 @@
+name: "General Issue"
+description: For general discussions, questions, or proposals
+title: "[General]: "
+labels: ["discussion"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        General issue form. Please provide the details below.
+
+  # Type of Issue
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Type
+      description: Select the category that best describes your issue.
+      options:
+        - Question
+        - Proposal
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  # Description
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please provide details about your question, proposal, or discussion topic.
+    validations:
+      required: true
+
+  # Screenshots
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Drag & drop images or paste screenshots here, if applicable.
+    validations:
+      required: false
+
+  # Environment info
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment / Version info
+      description: Provide relevant environment details if applicable.
+    validations:
+      required: false
+
+  # Code of Conduct
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: "Discussions"
+    url: https://github.com/ms-club-sliit/msclub-backend/discussions
+    about: Ask questions or discuss ideas here


### PR DESCRIPTION
This pull request introduces standardized GitHub issue templates to improve the reporting and triaging of bugs, feature requests, and general issues. It also disables blank issues and adds a link to the project's Discussions page for questions and open-ended topics.

**Issue template additions:**

* Added a detailed bug report template (`.github/ISSUE_TEMPLATE/1-bug-report.yml`) to guide users through reporting reproducible bugs, expected vs. actual behavior, environment info, and screenshots.
* Added a feature request template (`.github/ISSUE_TEMPLATE/2-feature-request.yml`) to structure suggestions for new features, including problem motivation, proposed solution, alternatives, and context.
* Added a general issue template (`.github/ISSUE_TEMPLATE/3-general.yml`) for questions, proposals, and other discussions, with fields for issue type, description, and optional screenshots or environment info.

**Repository configuration:**

* Disabled blank issues and added a contact link to the Discussions page via `.github/ISSUE_TEMPLATE/config.yml`, encouraging users to use structured templates or the Discussions forum.